### PR TITLE
Add extra sample rates

### DIFF
--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -57,6 +57,7 @@ PCM_SAMPLE_SIZE = {
 PCM_SAMPLE_RATE = {
     # map with sample rates used in slimproto."""
     # https://wiki.slimdevices.com/index.php/SlimProto_TCP_protocol.html#Command:_.22strm.22
+    # See %pcm_sample_rates in slimserver/Slim/Player/SqueezePlay.pm for definition of sample rates
     11000: b"0",
     22000: b"1",
     44100: b"3",
@@ -66,6 +67,10 @@ PCM_SAMPLE_RATE = {
     16000: b"7",
     24000: b"8",
     96000: b"9",
+    176400: b";",
+    192000: b"<",
+    352800: b"=",
+    384000: b">",
     0: b"?",
 }
 

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -57,7 +57,8 @@ PCM_SAMPLE_SIZE = {
 PCM_SAMPLE_RATE = {
     # map with sample rates used in slimproto."""
     # https://wiki.slimdevices.com/index.php/SlimProto_TCP_protocol.html#Command:_.22strm.22
-    # See %pcm_sample_rates in slimserver/Slim/Player/SqueezePlay.pm for definition of sample rates
+    # See %pcm_sample_rates in slimserver/Slim/Player/Squeezebox2.pm and 
+    # slimserver/Slim/Player/SqueezePlay.pm for definition of sample rates
     11000: b"0",
     22000: b"1",
     44100: b"3",
@@ -66,6 +67,7 @@ PCM_SAMPLE_RATE = {
     12000: b"6",
     16000: b"7",
     24000: b"8",
+    88200: b":",
     96000: b"9",
     176400: b";",
     192000: b"<",

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -57,7 +57,7 @@ PCM_SAMPLE_SIZE = {
 PCM_SAMPLE_RATE = {
     # map with sample rates used in slimproto."""
     # https://wiki.slimdevices.com/index.php/SlimProto_TCP_protocol.html#Command:_.22strm.22
-    # See %pcm_sample_rates in slimserver/Slim/Player/Squeezebox2.pm and 
+    # See %pcm_sample_rates in slimserver/Slim/Player/Squeezebox2.pm and
     # slimserver/Slim/Player/SqueezePlay.pm for definition of sample rates
     11000: b"0",
     22000: b"1",


### PR DESCRIPTION
The Slimdevices wiki isn't updated anymore so the reference for slimproto is the reference implementation slimserver. See https://github.com/Logitech/slimserver/blob/55f8e3f3d584baf6a3979a13fd23c7ef8e845d59/Slim/Player/SqueezePlay.pm#L223 for all sample rates supported by player type squeezeplay.