### PR TITLE
Do not send state changed event every second while playing

### DIFF
--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -575,7 +575,7 @@ class SlimClient:
             self._last_report = elapsed_seconds
             # send report with elapsed time only every second while playing
             # note that the (very) accurate elapsed/current is always available in the property
-            self.callback(EventType.PLAYER_UPDATED, self)
+            self.callback(EventType.PLAYER_TIME_UPDATED, self)
 
     def _process_stat_stmu(self, data):
         """Process incoming stat STMu message: Buffer underrun: Normal end of playback."""

--- a/aioslimproto/const.py
+++ b/aioslimproto/const.py
@@ -10,6 +10,7 @@ class EventType(Enum):
     """Enum with possible slim proto server events."""
 
     PLAYER_UPDATED = "player_updated"
+    PLAYER_TIME_UPDATED = "player_time_updated"
     PLAYER_CONNECTED = "player_connected"
     PLAYER_DISCONNECTED = "player_disconnected"
     PLAYER_NAME_RECEIVED = "player_name_received"


### PR DESCRIPTION
HA state machine is spammed with updates when the slimproto player is playing.
This change removes the per-second updates of the elapsed time when the player is playing from the "player_updated" event. Introduced new event "player_time_updated" for those who still want to subscribe to that event.