### PR TITLE
Auto pick next free port for CLI interface

### DIFF
--- a/aioslimproto/server.py
+++ b/aioslimproto/server.py
@@ -10,6 +10,7 @@ from .cli import SlimProtoCLI
 from .client import SlimClient
 from .const import EventType, SlimEvent
 from .discovery import start_discovery
+from .util import select_free_port
 
 EventCallBackType = Callable[[SlimEvent], None]
 EventSubscriptionType = Tuple[EventCallBackType, Tuple[EventType], Tuple[str]]
@@ -21,18 +22,23 @@ class SlimServer:
     def __init__(
         self,
         port: int = 3483,
-        cli_port: Optional[int] = 9090,
-        cli_port_json: Optional[int] = 9091,
+        cli_port: Optional[int] = 0,
+        cli_port_json: Optional[int] = 0,
     ) -> None:
         """
         Initialize SlimServer instance.
 
         control_port: The TCP port for the slimproto communication, default is 3483.
         cli_port: Optionally start a simple Telnet CLI server on this port for compatability
-        with players relying on the server providing this feature. None to disable.
-        cli_port_json: Same as cli port but it's newer JSOn RPC equivalent.
+        with players relying on the server providing this feature. None to disable, 0 for autoselect.
+        cli_port_json: Same as cli port but it's newer JSON RPC equivalent.
         """
         self.logger = logging.getLogger(__name__)
+        # if port is specified as 0, auto select a free port for the cli/json interface
+        if cli_port == 0:
+            cli_port = select_free_port(9090, 9190)
+        if cli_port_json == 0:
+            cli_port_json = select_free_port(cli_port + 1, 9190)
         self.port = port
         self.cli = SlimProtoCLI(self, cli_port, cli_port_json)
         self._subscribers: List[EventSubscriptionType] = []

--- a/aioslimproto/util.py
+++ b/aioslimproto/util.py
@@ -28,6 +28,22 @@ def get_hostname():
     return socket.gethostname()
 
 
+def is_port_in_use(port: int) -> bool:
+    """Check if port is in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as _sock:
+        try:
+            return _sock.connect_ex(("localhost", port)) == 0
+        except socket.gaierror:
+            return True
+
+
+def select_free_port(range_start: int, range_end: int) -> int:
+    """Automatically find available port within range."""
+    for port in range(range_start, range_end):
+        if not is_port_in_use(port):
+            return port
+
+
 def parse_capabilities(helo_data: bytes) -> Dict[str, Any]:
     """Try to parse device capabilities from HELO string."""
     # b"\x0c\x00\xb8'\xeb:D\xa2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\


### PR DESCRIPTION
Default port for the CLI interface is 9090 which is also popular for other applications.
Implement some logic to auto pick the next free port(s) for the CLI interface(s).

Note that the slim proto port 3483 can not be changed because that breaks the discovery.