### PR TITLE
Handle unsolicited disconnects and reconnects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,12 @@ repos:
     hooks:
       - id: pydocstyle
         exclude: ^examples/|^.venv/|^.vscode/
-  # - repo: local
-  #   hooks:
-  #     - id: pylint
-  #       name: pylint
-  #       entry: pylint
-  #       language: system
-  #       types: [python]
-  #       args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I"]
-  #       exclude: ^examples/|^.venv/|^.vscode/|^tests/
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I"]
+        exclude: ^examples/|^.venv/|^.vscode/|^tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,12 @@ repos:
     hooks:
       - id: pydocstyle
         exclude: ^examples/|^.venv/|^.vscode/
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I"]
-        exclude: ^examples/|^.venv/|^.vscode/|^tests/
+  # - repo: local
+  #   hooks:
+  #     - id: pylint
+  #       name: pylint
+  #       entry: pylint
+  #       language: system
+  #       types: [python]
+  #       args: ["-rn", "-sn", "--rcfile=pylintrc", "--fail-on=I"]
+  #       exclude: ^examples/|^.venv/|^.vscode/|^tests/

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -17,6 +17,8 @@ from enum import Enum
 from typing import Callable, Dict, List, TypedDict
 from urllib.parse import parse_qsl, urlparse
 
+from async_timeout import timeout
+
 from .const import EventType
 from .errors import UnsupportedContentType
 from .util import parse_capabilities, parse_headers
@@ -436,9 +438,9 @@ class SlimClient:
         # keep reading bytes from the socket
         while not (self._reader.at_eof() or self._writer.is_closing()):
             try:
-                async with asyncio.timeout(HEARTBEAT_INTERVAL * 2):
+                async with timeout(HEARTBEAT_INTERVAL * 2):
                     data = await self._reader.read(64)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 break
             # handle incoming data from socket
             buffer = buffer + data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+async-timeout


### PR DESCRIPTION
Fixes a race condition where a new socket connection is created while the old one is still active.

Also fixes unsollicited disconnects where the socket is disconnected unproperly. Use the heartbeat interval as timeout to detect a connection loss. 