### PR TITLE
A few bugfixes and small optimizations

### DIFF
--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -792,6 +792,10 @@ class SlimClient:
         No more decoded (uncompressed) data to play; triggers rebuffering.
         """
         self.logger.debug("STMo received - output underrun.")
+        if self._auto_play:
+            asyncio.create_task(self.stop())
+        else:
+            self.callback(EventType.PLAYER_OUTPUT_UNDERRUN, self)
 
     def _process_stat_stmp(self, data: bytes) -> None:
         """Process incoming stat STMp message: Pause confirmed."""

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -483,7 +483,7 @@ class SlimClient:
             if ext in CODEC_MAPPING:
                 mime_type = ext
 
-        codec_details = self._parse_codc(mime_type)
+        codec_details = self._parse_codc(mime_type) if mime_type else b"?????"
 
         if port not in (80, 443, "80", "443"):
             host += f":{port}"

--- a/aioslimproto/const.py
+++ b/aioslimproto/const.py
@@ -16,6 +16,7 @@ class EventType(Enum):
     PLAYER_NAME_RECEIVED = "player_name_received"
     PLAYER_DECODER_READY = "player_decoder_ready"
     PLAYER_DECODER_ERROR = "player_decoder_error"
+    PLAYER_OUTPUT_UNDERRUN = "player_output_underrun"
     PLAYER_BUFFER_READY = "player_buffer_ready"
     PLAYER_CLI_EVENT = "player_cli_event"
     PLAYER_BTN_EVENT = "player_btn_event"

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -25,10 +25,13 @@ class Font:
 
     def render(self, s, size=15):
         """Return a PIL image with this string rendered into it."""
-        self.cache.setdefault(size, ImageFont.truetype(self.filename, size))
-        font = self.cache[size]
-        _size = font.getsize(s)
-        im = Image.new("RGB", _size)
+        if size not in self.cache:
+            self.cache[size] = ImageFont.truetype(self.filename, size)
+        font: ImageFont.FreeTypeFont = self.cache[size]
+        bbox = font.getbbox(s)
+        width = abs(bbox[0] - bbox[2])
+        height = abs(bbox[1] - bbox[3])
+        im = Image.new("RGB", (width, height))
         draw = ImageDraw.Draw(im)
         draw.text((0, 0), s, font=font)
         return im


### PR DESCRIPTION
- Disable display controls by default
- Fix compatibility with recent Pilow versions
- Fallback to wilcard codec if no content type provided
- Handle output underrun
- Use autoplay on CODC request

Fixes compatibility with HA 2023.8 release as well as a bug report on the content type.