### PR TITLE
Unpin setuptools and wheel build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.3", "wheel~=0.37.1"]
+requires = ["setuptools>=62.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The wheel dependency is not explicitly needed. When a PEP 517 compliant build frontend invokes setuptools to build a wheel, it'll ask setuptools if it needs any additional dependencies, and setuptools will indicate it needs wheel (through the [get-requires-for-build-wheel](https://peps.python.org/pep-0517/#get-requires-for-build-wheel) hook).