### PR TITLE
Fix Ogg Vorbis playback

### DIFF
--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -181,7 +181,7 @@ FORMAT_BYTE = {
     "mp3": b"m",
     "flc": b"f",
     "wma": b"w",
-    "ogg": b"0",
+    "ogg": b"o",
     "aac": b"a",
     "alc": b"l",
     "dsf": b"p",


### PR DESCRIPTION
The format-byte for Ogg should be `o` (lowercase "Oh") not `0` (zero) – see also #239.