### PR TITLE
Lint on python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip build setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ test = [
 ]
 
 [tool.black]
-target-version = ['py311']
+target-version = ['py310']
 line-length = 100
 
 [tool.codespell]
@@ -92,7 +92,7 @@ ignore = ["PLR2004", "N818"]
 extend-exclude = ["app_vars.py"]
 unfixable = ["F841"]
 line-length = 100
-target-version = "py311"
+target-version = "py310"
 
 [tool.ruff.flake8-annotations]
 allow-star-arg-any = true


### PR DESCRIPTION
We can bump linting version when we bump the minimum Python version for the library.