### PR TITLE
Fixes for Display handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,14 @@ repos:
         types: [python]
         entry: scripts/run-in-env.sh ruff check --fix
         require_serial: true
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: ruff-format
         name: 🐶 Ruff Formatter
         language: system
         types: [python]
         entry: scripts/run-in-env.sh ruff format
         require_serial: true
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: check-ast
         name: 🐍 Check Python AST
         language: system
@@ -36,7 +36,7 @@ repos:
         language: system
         types: [text, executable]
         entry: scripts/run-in-env.sh check-executables-have-shebangs
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: check-json
         name: ｛ Check JSON files
         language: system
@@ -72,7 +72,7 @@ repos:
         language: system
         types: [text]
         entry: scripts/run-in-env.sh end-of-file-fixer
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       - id: no-commit-to-branch
         name: 🛑 Don't commit to main branch
         language: system
@@ -86,7 +86,7 @@ repos:
         language: system
         types: [text]
         entry: scripts/run-in-env.sh trailing-whitespace-fixer
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
       # TODO: enable mypy and work out issues
       # to become a fully typed package
       # - id: mypy

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -558,7 +558,11 @@ class SlimClient:
                 flags=0,
                 replay_gain=heartbeat_id,
             )
-            await self._render_display()
+            # Don't render display on first heartbeat.
+            # Prevents IntegerDivideByZero exception when LED-VU 
+            # enabled on Squeezelite-ESP32 devices without displays
+            if (self._last_heartbeat > 1) :
+                await self._render_display()
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 
     async def _socket_reader(self) -> None:
@@ -979,7 +983,7 @@ class SlimClient:
 
             # If player reports a display resolution with a value of 0
             if display_width == 0 or display_height == 0:
-                self.display_control.disabled = True  # noqa: FBT003
+                self.display_control.disabled = True
                 # Disable the display
             elif self.display_control.width != display_width:
                 # If the display resolution reported by the player doesn't match

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -979,14 +979,13 @@ class SlimClient:
 
             # If player reports a display resolution with a value of 0
             if display_width == 0 or display_height == 0:
-                self.display_control.disabled(True)  # noqa: FBT003
+                self.display_control.disabled = True  # noqa: FBT003
                 # Disable the display
-            elif self.display_control.image.width != display_width:
+            elif self.display_control.width != display_width:
                 # If the display resolution reported by the player doesn't match
                 # the display resolution we're currently using
-                self.display_control = None
-                self.display_control = SlimProtoDisplay(self, display_width)
-                # Re-instanciate SlimProtoDisplay with the correct resolution parameters
+                self.display_control.width = display_width
+                # Update the display width
 
     def _parse_codc(self, content_type: str) -> bytes:
         """Parse CODEC details from mime/content type string."""

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -991,7 +991,6 @@ class SlimClient:
             resolution = f"{display_width} x {display_height}"
             self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
 
-
     def _parse_codc(self, content_type: str) -> bytes:
         """Parse CODEC details from mime/content type string."""
         if "wav" in content_type or "pcm" in content_type:

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -973,11 +973,14 @@ class SlimClient:
             if display_height:
                 self.display_control.height = display_height
 
+            # Trigger an event callback for "PLAYER_DISPLAY_RESOLUTION"
             resolution = f"{display_width} x {display_height}"
             self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
 
+            # If player reports a display resolution with a value of 0
             if display_width == 0 or display_height == 0:
                 self.display_control.disabled(True)  # noqa: FBT003
+                # Disable the display
             elif self.display_control.image.width != display_width:
                 # If the display resolution reported by the player doesn't match
                 # the display resolution we're currently using

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -745,6 +745,12 @@ class SlimClient:
                 "code": code,
             },
         )
+    
+    def _process_dsco(self, data: bytes) -> None:
+        """Process incoming stat DSCO message (data stream disconnected)."""
+        self.logger.debug("DSCO received - data stream disconnected.")
+        # Some players may send this to indicate they have disconnected from the data stream
+        # Either becasue the stream ended, or because they have finished buffering the current file
 
     def _process_stat(self, data: bytes) -> None:
         """Redirect incoming STAT event from player to correct method."""
@@ -947,7 +953,7 @@ class SlimClient:
         if data_id == 0:
             # received player name
             self._device_name = data[1:-1].decode()
-            self.callback(self, EventType.PLAYER_NAME_RECEIVED)
+            self.callback(self, EventType.PLAYER_NAME_RECEIVED, self._device_name)
             self.logger = logging.getLogger(__name__).getChild(self._device_name)
         if data_id == 0xFE:
             # received display config (squeezebox2/squeezebox32)
@@ -965,6 +971,9 @@ class SlimClient:
                 self.display_control.width = display_width
             if display_height:
                 self.display_control.height = display_height
+            
+            resolution = (f"{display_width} x {display_height}")
+            self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
 
     def _parse_codc(self, content_type: str) -> bytes:
         """Parse CODEC details from mime/content type string."""

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -745,12 +745,13 @@ class SlimClient:
                 "code": code,
             },
         )
-    
+
     def _process_dsco(self, data: bytes) -> None:
         """Process incoming stat DSCO message (data stream disconnected)."""
         self.logger.debug("DSCO received - data stream disconnected.")
-        # Some players may send this to indicate they have disconnected from the data stream
-        # Either becasue the stream ended, or because they have finished buffering the current file
+        # Some players may send this to indicate they have disconnected
+        # from the data stream either because the stream ended, or because
+        # they have finished buffering the current file
 
     def _process_stat(self, data: bytes) -> None:
         """Redirect incoming STAT event from player to correct method."""
@@ -971,12 +972,13 @@ class SlimClient:
                 self.display_control.width = display_width
             if display_height:
                 self.display_control.height = display_height
-            
-            resolution = (f"{display_width} x {display_height}")
+
+            resolution = f"{display_width} x {display_height}"
             self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
 
             if self.display_control.image.width != display_width:
-                # If the display resolution reported by the player doesn't match the display resolution we're currently using
+                # If the display resolution reported by the player doesn't match
+                # the display resolution we're currently using
                 self.display_control = None
                 self.display_control = SlimProtoDisplay(self, display_width)
                 # Re-instanciate SlimProtoDisplay with the correct resolution parameters

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -561,7 +561,7 @@ class SlimClient:
             # Don't render display on first heartbeat.
             # Prevents IntegerDivideByZero exception when LED-VU
             # enabled on Squeezelite-ESP32 devices without displays
-            if (self._last_heartbeat > 1) :
+            if (self._last_heartbeat > 1):
                 await self._render_display()
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -561,7 +561,7 @@ class SlimClient:
             # Don't render display on first heartbeat.
             # Prevents IntegerDivideByZero exception when LED-VU
             # enabled on Squeezelite-ESP32 devices without displays
-            if (self._last_heartbeat > 1):
+            if self._last_heartbeat > 1:
                 await self._render_display()
             await asyncio.sleep(HEARTBEAT_INTERVAL)
 

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -977,10 +977,6 @@ class SlimClient:
             if display_height:
                 self.display_control.height = display_height
 
-            # Trigger an event callback for "PLAYER_DISPLAY_RESOLUTION"
-            resolution = f"{display_width} x {display_height}"
-            self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
-
             # If player reports a display resolution with a value of 0
             if display_width == 0 or display_height == 0:
                 self.display_control.disabled = True
@@ -990,6 +986,11 @@ class SlimClient:
                 # the display resolution we're currently using
                 self.display_control.width = display_width
                 # Update the display width
+            
+            # Trigger an event callback for "PLAYER_DISPLAY_RESOLUTION"
+            resolution = f"{display_width} x {display_height}"
+            self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
+
 
     def _parse_codc(self, content_type: str) -> bytes:
         """Parse CODEC details from mime/content type string."""

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -559,7 +559,7 @@ class SlimClient:
                 replay_gain=heartbeat_id,
             )
             # Don't render display on first heartbeat.
-            # Prevents IntegerDivideByZero exception when LED-VU 
+            # Prevents IntegerDivideByZero exception when LED-VU
             # enabled on Squeezelite-ESP32 devices without displays
             if (self._last_heartbeat > 1) :
                 await self._render_display()
@@ -986,7 +986,7 @@ class SlimClient:
                 # the display resolution we're currently using
                 self.display_control.width = display_width
                 # Update the display width
-            
+
             # Trigger an event callback for "PLAYER_DISPLAY_RESOLUTION"
             resolution = f"{display_width} x {display_height}"
             self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -976,7 +976,9 @@ class SlimClient:
             resolution = f"{display_width} x {display_height}"
             self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
 
-            if self.display_control.image.width != display_width:
+            if display_width == 0 or display_height == 0:
+                self.display_control.disabled(True)  # noqa: FBT003
+            elif self.display_control.image.width != display_width:
                 # If the display resolution reported by the player doesn't match
                 # the display resolution we're currently using
                 self.display_control = None

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -975,6 +975,12 @@ class SlimClient:
             resolution = (f"{display_width} x {display_height}")
             self.callback(self, EventType.PLAYER_DISPLAY_RESOLUTION, resolution)
 
+            if self.display_control.image.width != display_width:
+                # If the display resolution reported by the player doesn't match the display resolution we're currently using
+                self.display_control = None
+                self.display_control = SlimProtoDisplay(self, display_width)
+                # Re-instanciate SlimProtoDisplay with the correct resolution parameters
+
     def _parse_codc(self, content_type: str) -> bytes:
         """Parse CODEC details from mime/content type string."""
         if "wav" in content_type or "pcm" in content_type:

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -123,6 +123,7 @@ class SlimProtoDisplay:
         await self._render_display()
 
     async def set_lines(
+        """Set lines to display"""
         self,
         line_one: str = "",
         line_two: str = "",

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -61,7 +61,6 @@ class Font:
         draw.text((0, 0), text, font=font, fill=255)
         return im
 
-
 class SlimProtoDisplay:
     """Representation of a Slimproto display."""
 
@@ -123,15 +122,14 @@ class SlimProtoDisplay:
         await self._render_display()
 
     async def set_lines(
-        """Set lines to display"""
         self,
         line_one: str = "",
         line_two: str = "",
         fullscreen: str = "",
     ) -> None:
+        """Set (predefined) text lines on display."""
         if self.image.width != self.width:
             self.image = Image.new("1", (self.width, 32))
-        """Set (predefined) text lines on display."""
         if fullscreen:
             # clear regular lines when setting fullscreen
             self.last_line_one = ""

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -61,6 +61,7 @@ class Font:
         draw.text((0, 0), text, font=font, fill=255)
         return im
 
+
 class SlimProtoDisplay:
     """Representation of a Slimproto display."""
 

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import os
 import struct
+import logging
 from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw, ImageFont
@@ -108,6 +109,7 @@ class SlimProtoDisplay:
         visualisation_type: VisualisationType = VisualisationType.SPECTRUM_ANALYZER,
     ) -> None:
         """Initialize."""
+        self.logger = logging.getLogger(__name__)
         self.player = player
         self.width = width
         self.visualisation_type = visualisation_type
@@ -171,6 +173,8 @@ class SlimProtoDisplay:
 
         def pack() -> bytes:
             """Return the packed frame ready for transmission."""
+            if self.width != self.image.width:
+                self.logger.warn("Attempted to render %s x %s Image to %s x %s Display", self.image.width, self.image.height, self.width, self.height)
             pixmap = self.image.load()
             words = []
             for col in range(self.width):

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -10,7 +10,6 @@ https://github.com/winjer/squeal/blob/master/src/squeal/player/display.py
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 import struct
 from typing import TYPE_CHECKING
@@ -109,7 +108,6 @@ class SlimProtoDisplay:
         visualisation_type: VisualisationType = VisualisationType.SPECTRUM_ANALYZER,
     ) -> None:
         """Initialize."""
-        self.logger = logging.getLogger(__name__)
         self.player = player
         self.width = width
         self.visualisation_type = visualisation_type
@@ -130,6 +128,8 @@ class SlimProtoDisplay:
         line_two: str = "",
         fullscreen: str = "",
     ) -> None:
+        if self.image.width != self.width:
+            self.image = Image.new("1", (self.width, 32))
         """Set (predefined) text lines on display."""
         if fullscreen:
             # clear regular lines when setting fullscreen
@@ -173,14 +173,6 @@ class SlimProtoDisplay:
 
         def pack() -> bytes:
             """Return the packed frame ready for transmission."""
-            if self.width != self.image.width:
-                self.logger.warning(
-                    "Attempted to render %s x %s Image to %s x %s Display",
-                    self.image.width,
-                    self.image.height,
-                    self.width,
-                    self.height,
-                )
             pixmap = self.image.load()
             words = []
             for col in range(self.width):

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -114,7 +114,7 @@ class SlimProtoDisplay:
         self.width = width
         self.visualisation_type = visualisation_type
         # NOTE: height can only be 32, its not adjustable
-        self.image = Image.new("1", (width, 32))
+        self.image = Image.new("1", (self.width, 32))
         self.fonts: dict[str, Font] = {}
         for f in AVAILABLE_FONTS:
             self.fonts[f] = Font(f)

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -112,7 +112,7 @@ class SlimProtoDisplay:
         self.width = width
         self.visualisation_type = visualisation_type
         # NOTE: height can only be 32, its not adjustable
-        self.image = Image.new("1", (self.width, 32))
+        self.image = Image.new("1", (width, 32))
         self.fonts: dict[str, Font] = {}
         for f in AVAILABLE_FONTS:
             self.fonts[f] = Font(f)

--- a/aioslimproto/display.py
+++ b/aioslimproto/display.py
@@ -10,9 +10,9 @@ https://github.com/winjer/squeal/blob/master/src/squeal/player/display.py
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import struct
-import logging
 from typing import TYPE_CHECKING
 
 from PIL import Image, ImageDraw, ImageFont
@@ -174,7 +174,13 @@ class SlimProtoDisplay:
         def pack() -> bytes:
             """Return the packed frame ready for transmission."""
             if self.width != self.image.width:
-                self.logger.warn("Attempted to render %s x %s Image to %s x %s Display", self.image.width, self.image.height, self.width, self.height)
+                self.logger.warning(
+                    "Attempted to render %s x %s Image to %s x %s Display",
+                    self.image.width,
+                    self.image.height,
+                    self.width,
+                    self.height,
+                )
             pixmap = self.image.load()
             words = []
             for col in range(self.width):

--- a/aioslimproto/models.py
+++ b/aioslimproto/models.py
@@ -15,6 +15,7 @@ class EventType(Enum):
     PLAYER_CONNECTED = "player_connected"
     PLAYER_DISCONNECTED = "player_disconnected"
     PLAYER_NAME_RECEIVED = "player_name_received"
+    PLAYER_DISPLAY_RESOLUTION = "player_display_resolution"
     PLAYER_DECODER_READY = "player_decoder_ready"
     PLAYER_DECODER_ERROR = "player_decoder_error"
     PLAYER_OUTPUT_UNDERRUN = "player_output_underrun"

--- a/aioslimproto/volume.py
+++ b/aioslimproto/volume.py
@@ -139,14 +139,12 @@ class SlimProtoVolume:
     def increment(self) -> None:
         """Increment the volume."""
         self.volume += self.step
-        if self.volume > self.maximum:
-            self.volume = self.maximum
+        self.volume = min(self.volume, self.maximum)
 
     def decrement(self) -> None:
         """Decrement the volume."""
         self.volume -= self.step
-        if self.volume < self.minimum:
-            self.volume = self.minimum
+        self.volume = max(self.volume, self.minimum)
 
     def old_gain(self) -> int:
         """Return the "Old" gain value as required by the squeezebox."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
   "pytest-asyncio==0.23.8",
   "pytest-aiohttp==1.0.5",
   "pytest-cov==5.0.0",
-  "ruff==0.5.7",
+  "ruff==0.6.2",
   "safety==3.2.5",
   "tomli==2.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
   "pytest-asyncio==0.24.0",
   "pytest-aiohttp==1.0.5",
   "pytest-cov==5.0.0",
-  "ruff==0.6.2",
+  "ruff==0.5.7",
   "safety==3.2.5",
   "tomli==2.0.1",
 ]


### PR DESCRIPTION
This is my attempt at updates to display.py and client.py to fix issues with displays > 128px wide and causing divide by 0 errors on squeezelite-ESP32 devices using LED-VU display without a display connected.