### PR TITLE
Fix some volume bugs.

### DIFF
--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -35,6 +35,7 @@ from .models import (
     FORMAT_BYTE,
     PCM_SAMPLE_RATE,
     PCM_SAMPLE_SIZE,
+    SOFTWARE_PLAYER_TYPES,
     ButtonCode,
     EventType,
     MediaDetails,
@@ -466,7 +467,7 @@ class SlimClient:
 
         if mime_type is None:
             # try to get the audio format from file extension
-            for ext in (url[-3:], url.split(".")[-1]):
+            for ext in (url[-3:], url.rsplit(".", maxsplit=1)[-1]):
                 mime = f"audio/{ext}"
                 if mime in CODEC_MAPPING:
                     mime_type = mime
@@ -672,6 +673,15 @@ class SlimClient:
         self._device_type = DEVICE_TYPE.get(dev_id, "unknown device")
         self._capabilities = parse_capabilities(data)
         self.logger.debug("Player connected: %s", self.player_id)
+        # Use SqueezePlay volume params for software players (matching LMS behavior)
+        if self._device_type in SOFTWARE_PLAYER_TYPES:
+            current_volume = self.volume_control.volume
+            self.volume_control = SlimProtoVolume(
+                total_volume_range=-74,
+                step_point=25,
+                step_fraction=0.5,
+            )
+            self.volume_control.volume = current_volume
         # Set some startup settings for the player
         await self.send_frame(b"vers", b"7.9")
         # request player to send the player name

--- a/aioslimproto/models.py
+++ b/aioslimproto/models.py
@@ -52,12 +52,14 @@ DEVICE_TYPE = {
 
 # Software player types that use SqueezePlay volume parameters
 # (wider -74dB range with two-slope curve) instead of hardware Squeezebox2 defaults.
-SOFTWARE_PLAYER_TYPES: frozenset[str] = frozenset({
-    "squeezeplay",
-    "softsqueeze",
-    "softsqueeze3",
-    "softboom",
-})
+SOFTWARE_PLAYER_TYPES: frozenset[str] = frozenset(
+    {
+        "squeezeplay",
+        "softsqueeze",
+        "softsqueeze3",
+        "softboom",
+    }
+)
 
 
 class PlayerState(Enum):

--- a/aioslimproto/models.py
+++ b/aioslimproto/models.py
@@ -50,6 +50,15 @@ DEVICE_TYPE = {
     100: "squeezeesp32",
 }
 
+# Software player types that use SqueezePlay volume parameters
+# (wider -74dB range with two-slope curve) instead of hardware Squeezebox2 defaults.
+SOFTWARE_PLAYER_TYPES: frozenset[str] = frozenset({
+    "squeezeplay",
+    "softsqueeze",
+    "softsqueeze3",
+    "softboom",
+})
+
 
 class PlayerState(Enum):
     """Enum with the possible player states."""

--- a/aioslimproto/volume.py
+++ b/aioslimproto/volume.py
@@ -123,18 +123,25 @@ class SlimProtoVolume:
         128,
     ]
 
-    # new gain parameters, from the same place
-    total_volume_range: int = -50  # dB
-    step_point: int = (
-        -1
-    )  # Number of steps, up from the bottom, where a 2nd volume ramp kicks in.
-    step_fraction: int = (
-        1  # fraction of totalVolumeRange where alternate volume ramp kicks in.
-    )
+    def __init__(
+        self,
+        total_volume_range: int = -50,
+        step_point: int = -1,
+        step_fraction: float = 1,
+    ) -> None:
+        """Initialize class.
 
-    def __init__(self) -> None:
-        """Initialize class."""
+        :param total_volume_range: Total volume range in dB
+            (e.g. -50 for hardware, -74 for software players).
+        :param step_point: Steps from bottom where a 2nd volume
+            ramp kicks in (-1 to disable).
+        :param step_fraction: Fraction of totalVolumeRange where
+            alternate volume ramp kicks in.
+        """
         self.volume = 50
+        self.total_volume_range = total_volume_range
+        self.step_point = step_point
+        self.step_fraction = step_fraction
 
     def increment(self) -> None:
         """Increment the volume."""
@@ -164,8 +171,8 @@ class SlimProtoVolume:
         # y1 = mx1+b, y2 = mx2+b.
         # y2-y1 = m(x2 - x1)
         # y2 = m(x2 - x1) + y1
-        slope_high = max_volume_db - step_db / (100.0 - self.step_point)
-        slope_low = step_db - self.total_volume_range / (self.step_point - 0.0)
+        slope_high = (max_volume_db - step_db) / (100.0 - self.step_point)
+        slope_low = (step_db - self.total_volume_range) / (self.step_point - 0.0)
         x2 = self.volume
         if x2 > self.step_point:
             m = slope_high


### PR DESCRIPTION
Fix a few volume related bugs:
- Squeezelite identifies as a SqueezePlay software player, but aioslimproto applied the hardware Squeezebox2 volume curve to all  players — wrong curve, causing volume to drop off steeply below 60%
- The decibels() method also had a missing-parentheses bug that was harmless with the old params but would break with the correct SqueezePlay params
- Fixed both bugs and made volume params device-type-aware, so Squeezelite now gets the proper two-slope SqueezePlay curve matching LMS behavior