### PR TITLE
Handle but throw away additional args in _handle_serverstatus

### DIFF
--- a/aioslimproto/cli.py
+++ b/aioslimproto/cli.py
@@ -721,7 +721,7 @@ class SlimProtoCLI:
         player_id: str,
         start_index: int | str = 0,
         limit: int = 999,
-        *args,  # Handle but throw away any additional args
+        *args,  # Accept but discard any additional args
         **kwargs,
     ) -> PlayersResponse:
         """Handle players command."""
@@ -848,7 +848,7 @@ class SlimProtoCLI:
         player_id: str,
         start_index: int = 0,
         limit: int = 2,
-        *args,  # Handle but throw away any additional args
+        *args,  # Accept but discard any additional args
         **kwargs,
     ) -> ServerStatusResponse:
         """Handle server status command."""

--- a/aioslimproto/cli.py
+++ b/aioslimproto/cli.py
@@ -721,7 +721,7 @@ class SlimProtoCLI:
         player_id: str,
         start_index: int | str = 0,
         limit: int = 999,
-        *args,  # Added to gracefully handle non spec compliant devices
+        *args,  # Handle but throw away any additional args
         **kwargs,
     ) -> PlayersResponse:
         """Handle players command."""
@@ -848,6 +848,7 @@ class SlimProtoCLI:
         player_id: str,
         start_index: int = 0,
         limit: int = 2,
+        *args,  # Handle but throw away any additional args
         **kwargs,
     ) -> ServerStatusResponse:
         """Handle server status command."""


### PR DESCRIPTION
## Problem

PiCorePlayer devices send additional args for server status, similar to what was seen in `_handle_players`, based on the existing code comments.

I get the following error when using PiCorePlayer devices (piCorePlayer v10.0.0, Squeezelite v2.0.0-1476-pCP) with Music Assistant (2.6, 2.7, 2.8, beta).

```
TypeError: SlimProtoCLI._handle_serverstatus() takes from 2 to 4 positional arguments but 5 were given
```

Based on the documentation, the additional args are allowed: https://lyrion.org/reference/cli/compoundqueries/#serverstatus, https://lyrion.org/reference/cli/using-the-cli/#extended-query-format, rather than non-compliant.

Note, it doesn't prevent the devices from registering with Music-Assistant.

## Changes

Handle/discard the additional args in `_handle_serverstatus`, as done in `_handle_players`.

## Testing

Verified locally that the error does not appear on a refresh install of Music Assistant 2.8.7, with the change.