### PR TITLE
ci: pin external GitHub Actions to full commit SHAs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+
+<!-- What does this PR change and why? -->
+
+## Type of change
+
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Refactor / maintenance
+- [ ] CI / tooling
+- [ ] Dependency update
+
+## Checklist
+
+- [ ] I have applied a relevant label to this PR (required by CI)
+- [ ] Existing tests pass and/or new tests were added where relevant

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏷 Verify PR has a valid label
-        uses: ludeeus/action-require-labels@1.1.0
+        uses: ludeeus/action-require-labels@7ef0dba93830452589680da7cdea2e2c4c0f8dff # 1.1.0
         with:
          labels: >-
             breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v7.3.1
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get tag
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
@@ -31,7 +31,7 @@ jobs:
             fi
           fi
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install build
@@ -54,7 +54,7 @@ jobs:
         run: >-
           python3 -m build
       - name: Publish release to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
       - name: Check out code from GitHub
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -39,9 +39,9 @@ jobs:
 
   #   steps:
   #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v6.0.2
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v6.2.0
+  #       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
   #       with:
   #         python-version: ${{ matrix.python-version }}
   #     - name: Install dependencies

--- a/scripts/audit-action-pins.py
+++ b/scripts/audit-action-pins.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Audit GitHub Actions workflow/composite action refs.
+
+Fails (non-zero exit) if any external `uses:` reference is not pinned to a
+full 40-character commit SHA. Local refs (`./...`) and Docker refs
+(`docker://...`) are ignored. Run from the repository root:
+
+    python3 scripts/audit-action-pins.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml is optional, not a project dependency
+    yaml = None
+
+WORKFLOWS_DIR = Path(".github/workflows")
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(\S+)")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def find_uses_refs(text: str) -> list[str]:
+    """Extract `uses:` values, including within commented-out YAML blocks."""
+    refs = []
+    for line in text.splitlines():
+        stripped = line.lstrip("# ").strip()
+        match = USES_RE.match(stripped) or USES_RE.match(line)
+        if match:
+            refs.append(match.group(1))
+    return refs
+
+
+def is_pinned(ref: str) -> bool:
+    if ref.startswith("./") or ref.startswith("docker://"):
+        return True
+    if "@" not in ref:
+        return False
+    _, _, version = ref.rpartition("@")
+    return bool(SHA_RE.match(version))
+
+
+def validate_yaml(path: Path) -> str | None:
+    if yaml is None:
+        return None
+    try:
+        yaml.safe_load(path.read_text())
+    except yaml.YAMLError as exc:
+        return str(exc)
+    return None
+
+
+def main() -> int:
+    if not WORKFLOWS_DIR.is_dir():
+        print(f"No workflows directory found at {WORKFLOWS_DIR}", file=sys.stderr)
+        return 1
+
+    unpinned: list[tuple[Path, str]] = []
+    yaml_errors: list[tuple[Path, str]] = []
+
+    for path in sorted(WORKFLOWS_DIR.glob("*.y*ml")):
+        error = validate_yaml(path)
+        if error:
+            yaml_errors.append((path, error))
+            continue
+        for ref in find_uses_refs(path.read_text()):
+            if not is_pinned(ref):
+                unpinned.append((path, ref))
+
+    if yaml_errors:
+        print("YAML validation errors:")
+        for path, error in yaml_errors:
+            print(f"  {path}: {error}")
+
+    if unpinned:
+        print("Unpinned/mutable external action refs found:")
+        for path, ref in unpinned:
+            print(f"  {path}: {ref}")
+
+    if yaml_errors or unpinned:
+        return 1
+
+    suffix = "" if yaml is not None else " (YAML syntax check skipped: pyyaml not installed)"
+    print(f"OK: all external action refs are pinned to full commit SHAs and YAML is valid.{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Pins every external workflow `uses:` ref to its verified full commit SHA, keeping the exact version as an inline comment. **No versions were changed** — this is a mutable-ref → SHA-pin replacement only. Local refs (none used here besides workflow steps) are untouched.

| Action | Version (unchanged) | Pinned SHA |
|---|---|---|
| `actions/checkout` | v6.0.2 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-python` | v6.2.0 | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `release-drafter/release-drafter` | v7.3.1 | `693d20e7c1ce1a81d3a41962f85914253b518449` |
| `pypa/gh-action-pypi-publish` | v1.14.0 | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |
| `ludeeus/action-require-labels` | 1.1.0 | `7ef0dba93830452589680da7cdea2e2c4c0f8dff` |

All SHAs were verified directly against the GitHub Git Refs/Tags API (dereferencing annotated tags where needed) before being applied.

## Other changes

- Added a concise `.github/PULL_REQUEST_TEMPLATE.md` (none existed before).
- Added `scripts/audit-action-pins.py`: an audit/validation script that fails if any external `uses:` ref in `.github/workflows/*.y*ml` isn't pinned to a full 40-char commit SHA, and (when `pyyaml` is available) checks workflow YAML validity. Run with `python3 scripts/audit-action-pins.py`.
- Confirmed `.github/dependabot.yml` already has a `package-ecosystem: "github-actions"` entry — no change needed there, so Dependabot will keep proposing SHA-bump PRs going forward.

## Validation

Ran `scripts/audit-action-pins.py` locally: `OK: all external action refs are pinned to full commit SHAs and YAML is valid.`

## Note on related PRs

This PR supersedes the pinning work started in #541, #533, #532, and #531. Those PRs are not closed — leaving that decision to a maintainer — but this PR consolidates all pending action pins into one consistent change.

## Out of scope / not done here

- No merge performed.
- No branch-protection / required-status-check enforcement policy was added or changed.
