### PR TITLE
Fix the simple things that are causing test failures

### DIFF
--- a/aioslimproto/cli.py
+++ b/aioslimproto/cli.py
@@ -267,8 +267,8 @@ class SlimProtoCLI:
                         )
                     elif cmd_result is None:
                         result_str = ""
-                    elif (placeholder_idx := raw_params.index("?")) != -1:
-                        raw_params[placeholder_idx] = str(cmd_result)
+                    elif "?" in raw_params:
+                        raw_params[raw_params.index("?")] = str(cmd_result)
                         result_str = ""
                     else:
                         result_str = str(cmd_result)

--- a/aioslimproto/cli.py
+++ b/aioslimproto/cli.py
@@ -225,7 +225,7 @@ class SlimProtoCLI:
         try:
             while True:
                 raw_request = await reader.readline()
-                raw_request = raw_request.strip().decode("iso-8859-1")
+                raw_request = raw_request.strip().decode("utf-8")
                 if not raw_request:
                     break
                 # request comes in as url encoded strings, separated by space
@@ -243,8 +243,6 @@ class SlimProtoCLI:
 
                 args, kwargs = parse_args(command_params)
 
-                response: str = raw_request
-
                 # check if we have a handler for this command
                 # note that we only have support for very limited commands
                 # just enough for compatibility with players but not to be used as api
@@ -258,7 +256,7 @@ class SlimProtoCLI:
                         str(args),
                         str(kwargs),
                     )
-                    cmd_result: list[str] = handler(player_id, *args, **kwargs)
+                    cmd_result = handler(player_id, *args, **kwargs)
                     if asyncio.iscoroutine(cmd_result):
                         cmd_result = await cmd_result
 
@@ -267,13 +265,20 @@ class SlimProtoCLI:
                         result_str = " ".join(
                             urllib.parse.quote(x) for x in result_parts
                         )
-                    elif not cmd_result:
+                    elif cmd_result is None:
+                        result_str = ""
+                    elif (placeholder_idx := raw_params.index("?")) != -1:
+                        raw_params[placeholder_idx] = str(cmd_result)
                         result_str = ""
                     else:
                         result_str = str(cmd_result)
-                    response += " " + result_str
-                except (AttributeError, NotImplementedError):
+
+                    response: str = " ".join(urllib.parse.quote(x) for x in raw_params)
+                    if result_str:
+                        response += " " + result_str
+                except (AttributeError, NotImplementedError) as err:
                     # no handler found, forward as event
+                    self.logger.debug("No handler found", exc_info=err)
                     if player := self.server.get_player(player_id):
                         args_str = " ".join([command] + [str(x) for x in args])
                         player.callback(player, EventType.PLAYER_CLI_EVENT, args_str)
@@ -731,9 +736,9 @@ class SlimProtoCLI:
                 start_index = 0
             if isinstance(start_index, int) and index < start_index:
                 continue
-            if len(players) > limit:
+            if len(players) >= limit:
                 break
-            players.append(create_player_item(start_index + index, player))
+            players.append(create_player_item(index, player))
         return PlayersResponse(count=len(players), players_loop=players)
 
     async def _handle_status(
@@ -759,8 +764,8 @@ class SlimProtoCLI:
         result = {
             "player_name": player.name,
             "player_connected": int(player.connected),
-            "player_needs_upgrade": False,
-            "player_is_upgrading": False,
+            "player_needs_upgrade": 0,
+            "player_is_upgrading": 0,
             "power": int(player.powered),
             "signalstrength": 0,
             "waitingToPlay": 0,
@@ -912,7 +917,7 @@ class SlimProtoCLI:
         **kwargs,
     ) -> int | None:
         """Handle player mixer command."""
-        arg = args[0] if args else "?"
+        arg = args[0] if args else None
         player = self.server.get_player(player_id)
         if not player:
             return None
@@ -922,23 +927,23 @@ class SlimProtoCLI:
             return None
         if subcommand == "volume" and arg == "?":
             return player.volume_level
-        if subcommand == "volume" and "+" in arg:
+        if subcommand == "volume" and arg is not None and "+" in arg:
             volume_level = min(100, player.volume_level + int(arg.split("+")[1]))
             await player.volume_set(volume_level)
             return None
-        if subcommand == "volume" and "-" in arg:
+        if subcommand == "volume" and arg is not None and "-" in arg:
             volume_level = max(0, player.volume_level - int(arg.split("-")[1]))
             await player.volume_set(volume_level)
             return None
 
-        # <playerid> mixer muting <0|1|toggle|?|>
+        # <playerid> mixer muting <0|1|[toggle]|?|>
         if subcommand == "muting" and isinstance(arg, int):
             await player.mute(bool(arg))
             return None
-        if subcommand == "muting" and arg == "toggle":
+        if subcommand == "muting" and (arg == "toggle" or arg is None):
             await player.mute(not player.muted)
             return None
-        if subcommand == "muting":
+        if subcommand == "muting" and arg == "?":
             return int(player.muted)
         raise NotImplementedError(f"No handler for mixer/{subcommand}")
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -11,7 +11,8 @@ from urllib.parse import quote
 import pytest
 
 from aioslimproto.cli import SlimProtoCLI
-from aioslimproto.client import PlayerState, SlimClient
+from aioslimproto.client import SlimClient
+from aioslimproto.models import PlayerState
 from aioslimproto.server import SlimServer
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -208,10 +208,6 @@ class TestPlayersCommand:
         assert response == expected_response
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The pagination returns one player too many, "
-        "and the player index is incorrect"
-    )
     async def test_returns_second_player(
         self, writer: Mock, several_dummy_players: list[SlimClient]
     ) -> None:
@@ -258,10 +254,6 @@ class TestStatusCommand:
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The echoed command should have the ':' symbol URL-escaped"
-        " and no trailing whitespace"
-    )
     async def test_echoes_without_player(
         self, writer: Mock, dummy_server: SlimServer
     ) -> None:
@@ -274,10 +266,7 @@ class TestStatusCommand:
         assert response == expected_response
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded, "
-        "upgrade flags should be integers, not Python boolean literals"
-    )
+    @pytest.mark.xfail(reason="Many values are hard-coded")
     async def test_simple_example(self, writer: Mock, dummy_server: SlimServer) -> None:
         """The "simple example" on the reference page should work."""
         cli = SlimProtoCLI(dummy_server)
@@ -297,7 +286,7 @@ class TestStatusCommand:
                 "player_needs_upgrade": 0,
                 "player_is_upgrading": 0,
                 "power": 1,
-                "signalstrength": 0,
+                "signalstrength": 50,
                 "waitingToPlay": 0,
                 "mode": "stop",
                 "remote": 1,
@@ -305,9 +294,9 @@ class TestStatusCommand:
                 "time": 0,
                 "duration": 0,
                 "mixer volume": 50,
-                # Not documented, but sent by the server (https://github.com/LMS-Community/slimserver/blob/public/9.2/Slim/Control/Queries.pm#L4055)
+                # Not documented, but sent by the server (https://github.com/LMS-Community/slimserver/tree/cf756254749c489a1ac859dd4aad139b513dc655/Slim/Control/Queries.pm#L4055)
                 "player_ip": "127.0.0.1",
-                "playlist_cur_index": 0,
+                "playlist_cur_index": 1,
                 "playlist_tracks": 0,
                 "uuid": "player-uuid-1",
                 "seq_no": 1,
@@ -324,7 +313,6 @@ class TestMixerVolumeCommand:
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="The echoed command should not include the '?' symbol")
     async def test_get_volume(self, writer: Mock, dummy_player: SlimClient) -> None:
         """Should return the volume when requested with a '?'."""
         server = cast(
@@ -350,9 +338,6 @@ class TestMixerVolumeCommand:
         assert response == expected_response
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded"
-    )
     async def test_set_volume_absolute(
         self, writer: Mock, dummy_player: SlimClient
     ) -> None:
@@ -381,9 +366,6 @@ class TestMixerVolumeCommand:
         cast("Mock", dummy_player.volume_set).assert_called_once_with(75)
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded"
-    )
     async def test_set_volume_relative(
         self, writer: Mock, dummy_player: SlimClient
     ) -> None:
@@ -412,10 +394,7 @@ class TestMixerVolumeCommand:
         cast("Mock", dummy_player.volume_set).assert_called_once_with(75)
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded, "
-        "fractional values are not supported"
-    )
+    @pytest.mark.xfail(reason="Fractional values are not supported")
     async def test_set_volume_fractional(
         self, writer: Mock, dummy_player: SlimClient
     ) -> None:
@@ -451,9 +430,6 @@ class TestMixerMutingCommand:
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded"
-    )
     async def test_can_toggle_muting(
         self, writer: Mock, dummy_server: SlimServer, dummy_player: SlimClient
     ) -> None:
@@ -471,10 +447,6 @@ class TestMixerMutingCommand:
         cast("Mock", dummy_player.mute).assert_called_once_with(True)  # noqa: FBT003 # This is how it's called in the original code
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded, "
-        "keywordless calls are not supported"
-    )
     async def test_can_toggle_muting_without_keyword(
         self, writer: Mock, dummy_server: SlimServer, dummy_player: SlimClient
     ) -> None:
@@ -488,9 +460,6 @@ class TestMixerMutingCommand:
         cast("Mock", dummy_player.mute).assert_called_once_with(True)  # noqa: FBT003 # This is how it's called in the original code
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded"
-    )
     async def test_can_mute(
         self, writer: Mock, dummy_server: SlimServer, dummy_player: SlimClient
     ) -> None:
@@ -506,9 +475,6 @@ class TestMixerMutingCommand:
         cast("Mock", dummy_player.mute).assert_called_once_with(True)  # noqa: FBT003 # This is how it's called in the original code
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="The MAC-address in the echoed command should be URL-encoded"
-    )
     async def test_can_unmute(
         self, writer: Mock, dummy_server: SlimServer, dummy_player: SlimClient
     ) -> None:
@@ -524,12 +490,6 @@ class TestMixerMutingCommand:
         cast("Mock", dummy_player.mute).assert_called_once_with(False)  # noqa: FBT003 # This is how it's called in the original code
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason=(
-            "The MAC-address in the echoed command should be URL-encoded, "
-            "the question mark needs to be replaced with the actual response"
-        )
-    )
     async def test_can_query_muting(
         self, writer: Mock, dummy_server: SlimServer
     ) -> None:


### PR DESCRIPTION
A lot of the tests were failing due to incorrect URL-escapes, disregarding the query-response protocol of `volume ?` -> `volume 50`, and then there were also a few genuine bugs.